### PR TITLE
Fix user's post count

### DIFF
--- a/resources/views/users/posts/index.blade.php
+++ b/resources/views/users/posts/index.blade.php
@@ -5,7 +5,7 @@
         <div class="w-8/12">
             <div class="p-6">
                 <h1 class="text-2xl font-medium mb-1">{{ $user->name }}</h1>
-                <p>Posted {{ $posts->count() }} {{ Str::plural('post', $posts->count()) }} and received {{ $user->receivedLikes->count() }} likes</p>
+                <p>Posted {{ $user->posts->count() }} {{ Str::plural('post', $posts->count()) }} and received {{ $user->receivedLikes->count() }} likes</p>
             </div>
 
             <div class="bg-white p-6 rounded-lg">


### PR DESCRIPTION
In this case, it should be the total post count of a user rather that of some single page which would mostly be the value set in paginate

BTW, that is a very good tutorial, haven't finished watching it yet! So, I'm not so sure if it was intentionally :P